### PR TITLE
handle subjurisdiction without results

### DIFF
--- a/clarify/parser.py
+++ b/clarify/parser.py
@@ -319,14 +319,16 @@ class Parser(object):
             # The subjurisdiction elements are either ``Precinct`` for county or
             # city files or ``County`` for state files
             for subjurisdiction_el in vt_el.xpath('./Precinct') + vt_el.xpath('./County'):
-                subjurisdiction = result_jurisdiction_lookup[subjurisdiction_el.attrib['name']]
-                results.append(Result(
-                    contest=contest,
-                    vote_type=vote_type,
-                    jurisdiction=subjurisdiction,
-                    votes=int(subjurisdiction_el.attrib['votes']),
-                    choice=None
-                ))
+                if subjurisdiction_el.attrib['name'] in result_jurisdiction_lookup:
+                    subjurisdiction = result_jurisdiction_lookup[subjurisdiction_el.attrib['name']]
+
+                    results.append(Result(
+                        contest=contest,
+                        vote_type=vote_type,
+                        jurisdiction=subjurisdiction,
+                        votes=int(subjurisdiction_el.attrib['votes']),
+                        choice=None
+                    ))
 
         return results
 
@@ -386,14 +388,16 @@ class Parser(object):
             ))
 
             for subjurisdiction_el in vt_el.xpath('./Precinct') + vt_el.xpath('./County'):
-                subjurisdiction = result_jurisdiction_lookup[subjurisdiction_el.attrib['name']]
-                choice.add_result(Result(
-                    contest=contest,
-                    vote_type=vote_type,
-                    jurisdiction=subjurisdiction,
-                    votes=int(subjurisdiction_el.attrib['votes']),
-                    choice=choice
-                ))
+		if subjurisdiction_el.attrib['name'] in result_jurisdiction_lookup:
+                    subjurisdiction = result_jurisdiction_lookup[subjurisdiction_el.attrib['name']]
+                
+                    choice.add_result(Result(
+                        contest=contest,
+                        vote_type=vote_type,
+                        jurisdiction=subjurisdiction,
+                        votes=int(subjurisdiction_el.attrib['votes']),
+                        choice=choice
+                    ))
         return choice
 
     @classmethod


### PR DESCRIPTION
this handles the case where the precinct values isn't in the jurisdiction lookup table.   these values all haves 0 votes so they are omitted from the results.  (currently an exception is thrown and parses ceases).  This happens in the SC Aiken county precinct file -  for names like Emergency, and so on. 
 https://github.com/tamilyn/openelections-data-sc/blob/master/2016-parser/aiken.xml