### PR TITLE
fix spacing issue, and update tests to https

### DIFF
--- a/clarify/parser.py
+++ b/clarify/parser.py
@@ -388,16 +388,15 @@ class Parser(object):
             ))
 
             for subjurisdiction_el in vt_el.xpath('./Precinct') + vt_el.xpath('./County'):
-		if subjurisdiction_el.attrib['name'] in result_jurisdiction_lookup:
-                    subjurisdiction = result_jurisdiction_lookup[subjurisdiction_el.attrib['name']]
-                
-                    choice.add_result(Result(
-                        contest=contest,
-                        vote_type=vote_type,
-                        jurisdiction=subjurisdiction,
-                        votes=int(subjurisdiction_el.attrib['votes']),
-                        choice=choice
-                    ))
+              if subjurisdiction_el.attrib['name'] in result_jurisdiction_lookup:
+                  subjurisdiction = result_jurisdiction_lookup[subjurisdiction_el.attrib['name']]
+                  choice.add_result(Result(
+                      contest=contest,
+                      vote_type=vote_type,
+                      jurisdiction=subjurisdiction,
+                      votes=int(subjurisdiction_el.attrib['votes']),
+                      choice=choice
+                  ))
         return choice
 
     @classmethod

--- a/tests/test_jurisdiction.py
+++ b/tests/test_jurisdiction.py
@@ -135,9 +135,9 @@ COUNTIES_AR = [
 # Seem to start at 129035 and increment by 1
 COUNTY_IDS_PAIRS = {i:c for i, c in enumerate(COUNTIES_AR, start=129035)}
 
-COUNTY_REDIRECT_URL_RE = re.compile(r'http://results.enr.clarityelections.com/(?P<state>[A-Z]{2})/(?P<county>[A-Za-z\.]+)/(?P<page_id>\d+)/')
+COUNTY_REDIRECT_URL_RE = re.compile(r'https://results.enr.clarityelections.com/(?P<state>[A-Z]{2})/(?P<county>[A-Za-z\.]+)/(?P<page_id>\d+)/')
 
-COUNTY_URL_RE = re.compile(r'http://results.enr.clarityelections.com/(?P<state>[A-Z]{2})/(?P<county>[A-Za-z\.]+)/(?P<page_id>\d+)/(?P<page_id_2>\d+)/')
+COUNTY_URL_RE = re.compile(r'https://results.enr.clarityelections.com/(?P<state>[A-Z]{2})/(?P<county>[A-Za-z\.]+)/(?P<page_id>\d+)/(?P<page_id_2>\d+)/')
 
 def mock_county_response_callback(req):
     m = COUNTY_REDIRECT_URL_RE.match(req.url)
@@ -159,7 +159,7 @@ def mock_subjurisdiction_redirect_page_meta(page_id):
 
 class TestJurisdiction(TestCase):
     def test_construct(self):
-        url = 'http://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='state')
         self.assertEqual(jurisdiction.url, url)
 
@@ -167,9 +167,9 @@ class TestJurisdiction(TestCase):
     def test_get_subjurisdictions_state(self):
         # subjurisdiction url path is in script tag
         # Construct a Jurisdiction for Kentucky's 2014 Primary Election
-        url = 'http://results.enr.clarityelections.com/KY/50972/131636/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/KY/50972/131636/en/summary.html'
         # Mock the response for the county list
-        county_url = 'http://results.enr.clarityelections.com/KY/50972/131636/en/select-county.html'
+        county_url = 'https://results.enr.clarityelections.com/KY/50972/131636/en/select-county.html'
         response_body_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
             'data', 'select-county__KY__50972__131636.html')
         with open(response_body_path) as f:
@@ -213,7 +213,7 @@ class TestJurisdiction(TestCase):
     def test_get_sub_jurisdictions_none(self):
         """A jurisdiction with no sub-jurisdictions should return an empty list"""
         # Construct a Jurisdiction for Rockford City, IL 2014 General Election
-        url = 'http://results.enr.clarityelections.com/IL/Rockford/54234/148685/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/IL/Rockford/54234/148685/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='city')
         jurisdictions = jurisdiction.get_subjurisdictions()
         # A city has no sub-jurisdictions with results
@@ -223,7 +223,7 @@ class TestJurisdiction(TestCase):
     def test_get_sub_jurisdictions_none_web01(self):
         """A jurisdiction with no sub-jurisdictions with Web01 in url should return an empty list"""
         # Construct a Jurisdiction for Middlesex County, NJ 2013 General Election
-        url = 'http://results.enr.clarityelections.com/NJ/Middlesex/46982/117336/Web01/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/NJ/Middlesex/46982/117336/Web01/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='county')
         jurisdictions = jurisdiction.get_subjurisdictions()
         # A city has no sub-jurisdictions with results
@@ -235,34 +235,34 @@ class TestJurisdiction(TestCase):
         A jurisdiction with Web01 in url should have a parsed URL that
         removes "Web01" from the URL"""
         # Construct a Jurisdiction for Arkansas 2014 General Election
-        url = 'http://results.enr.clarityelections.com/AR/53237/149294/Web01/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/AR/53237/149294/Web01/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='state')
         self.assertNotIn('Web01', jurisdiction.parsed_url.path)
 
     def test_report_url_xml(self):
         # Construct a Jurisdiction for Appling County, GA 2014 Primary Election
-        url = 'http://results.enr.clarityelections.com/GA/Appling/52178/139522/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/GA/Appling/52178/139522/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='county')
-        expected_url = 'http://results.enr.clarityelections.com/GA/Appling/52178/139522/reports/detailxml.zip'
+        expected_url = 'https://results.enr.clarityelections.com/GA/Appling/52178/139522/reports/detailxml.zip'
         self.assertEqual(jurisdiction.report_url('xml'), expected_url)
 
     def test_report_url_txt(self):
         # Construct a Jurisdiction for Kentucky 2010 Primary Election
-        url = 'http://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='county')
-        expected_url = 'http://results.enr.clarityelections.com/KY/15261/30235/reports/detailtxt.zip'
+        expected_url = 'https://results.enr.clarityelections.com/KY/15261/30235/reports/detailtxt.zip'
         self.assertEqual(jurisdiction.report_url('txt'), expected_url)
 
     def test_report_url_xls(self):
         # Construct a Jurisdiction for Colorado 2014 General Election
-        url = 'http://results.enr.clarityelections.com/CO/53335/149144/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/CO/53335/149144/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='county')
-        expected_url = 'http://results.enr.clarityelections.com/CO/53335/149144/reports/detailxls.zip'
+        expected_url = 'https://results.enr.clarityelections.com/CO/53335/149144/reports/detailxls.zip'
         self.assertEqual(jurisdiction.report_url('xls'), expected_url)
 
     def test_summary_url(self):
         # Construct a Jurisdiction for Colorado 2014 General Election
-        url = 'http://results.enr.clarityelections.com/CO/53335/149144/en/summary.html'
+        url = 'https://results.enr.clarityelections.com/CO/53335/149144/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='state')
-        expected_url = 'http://results.enr.clarityelections.com/CO/53335/149144/reports/summary.zip'
+        expected_url = 'https://results.enr.clarityelections.com/CO/53335/149144/reports/summary.zip'
         self.assertEqual(jurisdiction.summary_url, expected_url)


### PR DESCRIPTION
fixed indentation issue in parser.y

updated tests to use https (GET were failing with connection refused with http) .  The jurisdiction tests are still failed I believe because it looks like the generated urls are http (not https).
