### PR TITLE
Add support for determining the latest summary URL

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ codecov
 coverage
 nose
 responses
+unittest2; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     tests_require=[
         'nose',
         'responses',
+        "unittest2; python_version < '3.4'"
     ],
     test_suite='nose.collector',
     keywords=['elections', 'Clarity', 'results', 'parser', 'scraper'],


### PR DESCRIPTION
Adds class methods `get_current_ver` and `get_latest_summary_url` to
Jursidiction.

Also adds helper class method `_url_ensure_trailing_slash` to
Jurisdiction to ensure a given URL ends in a slash.

Closes #16.