### PR TITLE
Add validation checks in Jurisdiction constructor

### DIFF
--- a/clarify/jurisdiction.py
+++ b/clarify/jurisdiction.py
@@ -8,7 +8,7 @@ import lxml.html
 from lxml.cssselect import CSSSelector
 
 CLARITY_RESULTS_HOSTNAME = "results.enr.clarityelections.com"
-SUPPORTED_LEVELS = ['state', 'county', 'city']
+SUPPORTED_LEVELS = ['state', 'county', 'city', 'precinct']
 
 
 class Jurisdiction(object):
@@ -23,27 +23,36 @@ class Jurisdiction(object):
         """
         To create an instance, pass a Clarity results URL for the top-level
         political jurisdiction (a state, for example), and the corresponding
-        level in lowercase ("state" or "county").
+        level in lowercase ("state", "county", "city", or "precinct").
         """
 
+        # Preliminary check for any type which is not string-like
+        if url == None:
+            raise TypeError('Invalid url parameter')
+        try:
+            # Attempt to convert to str
+            url = str(url)
+        except Exception as error:
+            # If converting to str failed, raise type error
+            raise TypeError('Invalid url parameter')
         if type(url) != str:
-            raise Exception('Invalid url parameter')
+            raise TypeError('Invalid url parameter')
         # if url is an HTTP URL to Clarity Election Results
-        elif len(url) >= 40 and url[0:40] == 'http://' + CLARITY_RESULTS_HOSTNAME + '/':
+        if len(url) >= 40 and url[0:40] == 'http://' + CLARITY_RESULTS_HOSTNAME + '/':
             # Replace HTTP with HTTPS; retain the string after the URL origin
             url = 'https://' + CLARITY_RESULTS_HOSTNAME + '/' + url[40]
         # if url is not in the allowed list of supported origins
         if len(url) < 41 or url[0:41] != 'https://' + CLARITY_RESULTS_HOSTNAME + '/':
-            raise Exception('Unsupported url origin')
+            raise ValueError('Unsupported url origin')
         self.url = url
         self.parsed_url = self._parse_url()
         self.state = self._get_state_from_url()
 
         if type(level) != str:
-            raise Exception('Invalid level parameter')
+            raise TypeError('Invalid level parameter')
         level = level.lower()
         if level not in SUPPORTED_LEVELS:
-            raise Exception('Unsupported level')
+            raise ValueError('Unsupported level')
         self.level = level
         self.name = name
         self.summary_url = self._get_summary_url()

--- a/clarify/jurisdiction.py
+++ b/clarify/jurisdiction.py
@@ -32,6 +32,10 @@ class Jurisdiction(object):
         try:
             # Attempt to convert to str
             url = str(url)
+        except TypeError as type_error:
+            raise type_error
+        except ValueError as value_error:
+            raise value_error
         except Exception as error:
             # If converting to str failed, raise type error
             raise TypeError('Invalid url parameter')

--- a/clarify/jurisdiction.py
+++ b/clarify/jurisdiction.py
@@ -7,6 +7,9 @@ from requests_futures.sessions import FuturesSession
 import lxml.html
 from lxml.cssselect import CSSSelector
 
+CLARITY_RESULTS_HOSTNAME = "results.enr.clarityelections.com"
+SUPPORTED_LEVELS = ['state', 'county', 'city']
+
 
 class Jurisdiction(object):
 
@@ -23,9 +26,24 @@ class Jurisdiction(object):
         level in lowercase ("state" or "county").
         """
 
+        if type(url) != str:
+            raise Exception('Invalid url parameter')
+        # if url is an HTTP URL to Clarity Election Results
+        elif len(url) >= 40 and url[0:40] == 'http://' + CLARITY_RESULTS_HOSTNAME + '/':
+            # Replace HTTP with HTTPS; retain the string after the URL origin
+            url = 'https://' + CLARITY_RESULTS_HOSTNAME + '/' + url[40]
+        # if url is not in the allowed list of supported origins
+        if len(url) < 41 or url[0:41] != 'https://' + CLARITY_RESULTS_HOSTNAME + '/':
+            raise Exception('Unsupported url origin')
         self.url = url
         self.parsed_url = self._parse_url()
         self.state = self._get_state_from_url()
+
+        if type(level) != str:
+            raise Exception('Invalid level parameter')
+        level = level.lower()
+        if level not in SUPPORTED_LEVELS:
+            raise Exception('Unsupported level')
         self.level = level
         self.name = name
         self.summary_url = self._get_summary_url()

--- a/tests/test_jurisdiction.py
+++ b/tests/test_jurisdiction.py
@@ -166,10 +166,53 @@ def mock_subjurisdiction_redirect_page_meta(page_id):
 
 
 class TestJurisdiction(TestCase):
+    # Test the constructor
     def test_construct(self):
+        """
+        A Jurisdiction with a valid, supported URL and level string should create a class instance and not raise an Exception.
+        """
         url = 'https://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
         jurisdiction = Jurisdiction(url=url, level='state')
         self.assertEqual(jurisdiction.url, url)
+
+    def test_construct_invalid_url_type(self):
+        """
+        A Jurisdiction with an invalid URL data type should raise an Exception.
+        """
+        with self.assertRaises(Exception):
+            Jurisdiction(url=None, level='state')
+
+    def test_construct_invalid_url(self):
+        """
+        A Jurisdiction with an invalid URL should raise an Exception.
+        """
+        with self.assertRaises(Exception):
+            Jurisdiction(url='foo', level='state')
+
+    def test_construct_invalid_hostname(self):
+        """
+        A Jurisdiction with an unsupported hostname in the URL should raise an Exception.
+        """
+        url = 'https://bad.hostname/KY/15261/30235/en/summary.html'
+        with self.assertRaises(Exception):
+            Jurisdiction(url=url, level='state')
+
+    def test_construct_no_level(self):
+        """
+        A Jurisdiction with a valid, supported hostname but no level in the URL should raise an Exception.
+        """
+        url = 'https://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
+        with self.assertRaises(Exception):
+            Jurisdiction(url=url)
+
+    def test_construct_invalid_level_str(self):
+        """
+        A Jurisdiction with a valid, supported hostname but an invalid level in the URL should raise an Exception.
+        """
+        url = 'https://results.enr.clarityelections.com/KY/15261/30235/en/summary.html'
+        with self.assertRaises(Exception):
+            Jurisdiction(url=url, level='foo')
+
 
     @responses.activate
     def test_get_subjurisdictions_state(self):


### PR DESCRIPTION
Add validation of parameters to Jurisdiction constructor. The constructor now raises Exceptions where it didn't before (BREAKING CHANGE).

This PR prevents all instances of Jurisdiction from working with any hostname other than `results.enr.clarityelections.com`. This will cause breakage if any downstream users depend on any other hostnames/CNAMEs (potential BREAKING CHANGE). I couldn't find any documentation about Clarify about whether they support such features or not.

This PR also restricts the valid values of `level` to `['state', 'county', 'city']` (BREAKING CHANGE). Are there any other valid values?