### PR TITLE
Fix broken get_current_ver logic and unit test

### DIFF
--- a/clarify/jurisdiction.py
+++ b/clarify/jurisdiction.py
@@ -2,11 +2,17 @@ import concurrent.futures
 
 from six.moves.urllib import parse
 
+import re
 import requests
 from requests_futures.sessions import FuturesSession
 import lxml.html
 from lxml.cssselect import CSSSelector
 
+# base_uri is the path prefix including the folloing named groups:
+# - state_id (required)
+# - jurisdiction_name (optional) -- the city/county/precinct name, with URL-safe whitespace
+# - election_id (required)
+BASE_URL_REGEX = re.compile(r'^(?P<base_uri>/(?P<state_id>[A-Z]{2,2})/((?P<jurisdiction_name>[A-Za-z_.]+)/)?(?P<election_id>[0-9]+))/')
 
 class Jurisdiction(object):
 
@@ -44,22 +50,23 @@ class Jurisdiction(object):
     @classmethod
     def get_current_ver(cls, election_url):
         election_url_parts = parse.urlsplit(cls._url_ensure_trailing_slash(election_url))
-        if 'Web02' in election_url or 'web.' in election_url:
-            cls.parsed_url = election_url_parts._replace(path="/".join(election_url_parts.path.split('/')[:3]) + "/current_ver.txt", fragment='')
-            election_url_parts =  cls.parsed_url
-        else:
-            election_url_parts = election_url_parts._replace(path=election_url_parts.path + "current_ver.txt")
-
-        current_ver_url = parse.urlunsplit(election_url_parts)
-
-        current_ver_response = requests.get(current_ver_url)
-
-        try:
-            current_ver_response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            return None
-
-        return current_ver_response.text
+        base_url_matches = BASE_URL_REGEX.match(election_url_parts.path)
+        base_uri = base_url_matches.group('base_uri') if base_url_matches else None
+        # possible version filenames
+        possible_filenames = ['/current_ver.txt']
+        ret = None
+        for filename in possible_filenames:
+            # if we have already seen a 200-status response
+            if ret == None:
+                election_url_parts = election_url_parts._replace(path=base_uri + filename)
+                current_ver_url = parse.urlunsplit(election_url_parts)
+                current_ver_response = requests.get(current_ver_url)
+                try:
+                    current_ver_response.raise_for_status()
+                    ret = current_ver_response.text
+                except requests.exceptions.HTTPError:
+                    ret = None
+        return ret
 
     @classmethod
     def get_latest_summary_url(cls, election_url):

--- a/clarify/jurisdiction.py
+++ b/clarify/jurisdiction.py
@@ -51,7 +51,9 @@ class Jurisdiction(object):
     def get_current_ver(cls, election_url):
         election_url_parts = parse.urlsplit(cls._url_ensure_trailing_slash(election_url))
         base_url_matches = BASE_URL_REGEX.match(election_url_parts.path)
-        base_uri = base_url_matches.group('base_uri') if base_url_matches else None
+        if not base_url_matches:
+            return None
+        base_uri = base_url_matches.group('base_uri')
         # possible version filenames
         possible_filenames = ['/current_ver.txt']
         ret = None

--- a/tests/test_jurisdiction.py
+++ b/tests/test_jurisdiction.py
@@ -205,6 +205,9 @@ class TestJurisdiction(TestCase):
             "https://results.enr.clarityelections.com/KY/50972/131636/reports/summary.zip",
             status=200,
         )
+        responses.add(responses.GET, 'https://results.enr.clarityelections.com/KY/50972/current_ver.txt',
+                      body='131636', status=200,
+                      content_type='text/plain')
 
         jurisdiction = Jurisdiction(url=url, level='state')
         jurisdictions = jurisdiction.get_subjurisdictions()
@@ -270,6 +273,9 @@ class TestJurisdiction(TestCase):
             url=re.compile(r"^https://results.enr.clarityelections.com/AR/(.+/[0-9]+/[0-9]+/Web01/en/summary.html|(.+/)?[0-9]+/[0-9]+/reports/summary.zip)$"),
             status=200,
         )
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/[A-Z]{2,2}/([A-Za-z_.]+/)?[0-9]+/current_ver.txt'),
+                      body='12345', status=200,
+                      content_type='text/plain')
 
         # Construct a Jurisdiction for Arkansas 2014 General Election
         url = "https://results.enr.clarityelections.com/AR/53237/149294/Web01/en/summary.html"
@@ -335,28 +341,71 @@ class TestJurisdiction(TestCase):
         self.assertEqual(Jurisdiction._url_ensure_trailing_slash(url_with), url_with)
         self.assertEqual(Jurisdiction._url_ensure_trailing_slash(url_without), url_with)
 
-    def test_get_current_ver(self):
-        election_urls = [
-            "https://results.enr.clarityelections.com/CO/63746/",
-            "https://results.enr.clarityelections.com/CO/Boulder/43040/",
-            "https://results.enr.clarityelections.com/CO/Bogus/43040/",
-            "https://results.enr.clarityelections.com/AR/75879/",
-        ]
-        expected_current_vers = [
-            "184388",
-            "114182",
-            None,
-            "208723",
-        ]
+    @responses.activate
+    def test_get_current_ver_state_web01_1st(self):
+        """
+        A state jurisdiction with Web01 in url should find the current version at the expected URL
+        """
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/[A-Z]{2,2}/([A-Za-z_.]+/)?[0-9]+/current_ver.txt'),
+                      body='184388', status=200,
+                      content_type='text/plain')
+        current_ver = Jurisdiction.get_current_ver("https://results.enr.clarityelections.com/CO/63746/")
+        self.assertEqual(current_ver, "184388")
 
-        for (election_url, expected_current_ver) in dict(zip(election_urls, expected_current_vers)).items():
-            with self.subTest(election_url=election_url, expected_current_ver=expected_current_ver):
-                current_ver = Jurisdiction.get_current_ver(election_url)
+    @responses.activate
+    def test_get_current_ver_state_web01_2nd(self):
+        """
+        A state jurisdiction with Web01 in url should find the current version at the expected URL
+        """
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/[A-Z]{2,2}/([A-Za-z_.]+/)?[0-9]+/current_ver.txt'),
+                      body='149292', status=200,
+                      content_type='text/plain')
+        current_ver = Jurisdiction.get_current_ver("https://results.enr.clarityelections.com/AR/Arkansas/53239/")
+        self.assertEqual(current_ver, "149292")
 
-                if expected_current_ver is None:
-                    self.assertIsNone(current_ver)
-                else:
-                    self.assertEqual(current_ver, expected_current_ver)
+    @responses.activate
+    def test_get_current_ver_state_web02(self):
+        """
+        A state jurisdiction with Web02 in url should find the current version at the expected URL
+        """
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/[A-Z]{2,2}/([A-Za-z_.]+/)?[0-9]+/current_ver.txt'),
+                      body='208723', status=200,
+                      content_type='text/plain')
+        current_ver = Jurisdiction.get_current_ver("https://results.enr.clarityelections.com/AR/75879/")
+        self.assertEqual(current_ver, "208723")
+
+    @responses.activate
+    def test_get_current_ver_county_legacy(self):
+        """
+        A county jurisdiction with legacy in url should find the current version at the expected URL
+        """
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/[A-Z]{2,2}/([A-Za-z_.]+/)?[0-9]+/current_ver.txt'),
+                      body='114182', status=200,
+                      content_type='text/plain')
+        current_ver = Jurisdiction.get_current_ver("https://results.enr.clarityelections.com/CO/Boulder/43040/")
+        self.assertEqual(current_ver, "114182")
+
+    @responses.activate
+    def test_get_current_ver_state_bogus(self):
+        """
+        A non-existant state jurisdiction should return None from get_current_ver 
+        """
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/BG/[0-9]+/(current_ver|cur_version).txt'),
+                      body='', status=404,
+                      content_type='text/plain')
+        current_ver = Jurisdiction.get_current_ver("https://results.enr.clarityelections.com/BG/12345/")
+        self.assertIsNone(current_ver)
+
+    @responses.activate
+    def test_get_current_ver_county_bogus(self):
+        """
+        A non-existant county jurisdiction should return None from get_current_ver 
+        """
+        responses.add(responses.GET, re.compile(r'^https://results.enr.clarityelections.com/[A-Z]{2,2}/Bogus/[0-9]+/(current_ver|cur_version).txt'),
+                      body='', status=404,
+                      content_type='text/plain')
+        current_ver = Jurisdiction.get_current_ver("https://results.enr.clarityelections.com/CO/Bogus/43040/")
+        self.assertIsNone(current_ver)
 
     def test_get_latest_summary_url(self):
         election_urls = [
@@ -369,7 +418,7 @@ class TestJurisdiction(TestCase):
             "https://results.enr.clarityelections.com/CO/63746/184388/Web01/en/summary.html",
             "https://results.enr.clarityelections.com/CO/Boulder/43040/114182/en/summary.html",
             None,
-            None,  # TODO: This uses new-style summary pages.
+            "https://results.enr.clarityelections.com/AR/75879//208723/json/en/summary.json", # exact URL generated, not most desirable
         ]
 
         for (election_url, expected_url) in dict(zip(election_urls, expected_urls)).items():


### PR DESCRIPTION
This PR fixes incorrect logic with `get_current_ver` and the relevant unit tests.

A broken unit test:
```
requests.exceptions.ConnectionError: Connection refused by Responses - the call doesn't match any registered mock.
Request: 
- GET https://results.enr.clarityelections.com/KY/50972/131636/en/summary.html/current_ver.txt
```
revealed that this function doesn't correctly truncate the URL path before appending `/current_ver.txt`. The correct URL should be `https://results.enr.clarityelections.com/KY/50972/current_ver.txt` (the version file is always in the `election_id` directory).

The logic fix involved using a RegEx to detect the first 2 or 3 directories of the URL path (depending on jurisdiction level of the election page).

Also, I broke the relevant 1 test function with 4 loop iterations into 1 test function per intent which helps name+describe the intent for each test and helps developers quickly identify which test/intent failed.